### PR TITLE
Update zzz_RemoteTechAddMissingModuleSPUPassive.cfg

### DIFF
--- a/GameData/zFinal_FilterExtensions/zzz_RemoteTechAddMissingModuleSPUPassive.cfg
+++ b/GameData/zFinal_FilterExtensions/zzz_RemoteTechAddMissingModuleSPUPassive.cfg
@@ -405,7 +405,6 @@ PART
     name = GD_RT_unmannedTech
     module = Part
     author = Gordon Dry (used under permission of Allis Tauri)
-	RSSROConfig = true
 
     MODEL
     {
@@ -431,7 +430,6 @@ PART
     name = GD_RT_advUnmannedA
     module = Part
     author = Gordon Dry (used under permission of Allis Tauri)
-	RSSROConfig = true
 
     MODEL
     {
@@ -503,3 +501,9 @@ PART
     // title = RT: crew pods embedded transmitter
     // description = Crewable pods now have a basic embedded transmission antenna.
 // }
+
+@PART[GD_RT_*]:NEEDS[RealSolarSystem]:AFTER[RemoteTech]
+{
+	+RSSROConfig = true
+}
+


### PR DESCRIPTION
I'm making this PR only because I see no way to open an issue; so, I apologize if I'm doing something wrong.

Anywho, I'm getting these warnings (yeah, I know they don't mean much but I'm a zero-defect kinda guy.):

[LOG 11:10:34.924] PartLoader: Compiling Part 'zFinal_FilterExtensions/zzz_RemoteTechAddMissingModuleSPUPassive/GD_RT_unmannedTech'
[WRN 11:10:34.931] PartLoader Warning: Variable RSSROConfig not found in Part
[LOG 11:10:34.949] PartLoader: Compiling Part 'zFinal_FilterExtensions/zzz_RemoteTechAddMissingModuleSPUPassive/GD_RT_advUnmannedA'
[WRN 11:10:34.956] PartLoader Warning: Variable RSSROConfig not found in Part

Those are the only two parts currently created in this config; everything else is commented out.  Currently, I'm just commenting out those two lines.  But, thinking forward, wouldn't deleting the offending lines and putting something like this at the bottom avoid the above?

@PART[GD_RT_*]:NEEDS[RealSolarSystem]:AFTER[RemoteTech]
{
	+RSSROConfig = true
}